### PR TITLE
Error handling + override rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     gd-dev \
     geoip-dev \
     perl-dev \
+    procps \
     luajit-dev \
   && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
   && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
@@ -166,11 +167,11 @@ RUN apk --update add --virtual build-dependencies gcc bash python-dev build-base
   && make install \
   && apk del build-dependencies \
   && rm -rf /root/librdkafka
-  
+
 RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     echo /etc/apk/respositories && \
     apk update && apk upgrade &&\
-    apk add --no-cache \        
+    apk add --no-cache \
     bash \
     openssh-client \
     wget \
@@ -237,11 +238,19 @@ COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 RUN mkdir -p /etc/nginx/sites-available/ && \
 mkdir -p /etc/nginx/sites-enabled/ && \
 mkdir -p /etc/nginx/ssl/ && \
+mkdir -p /etc/nginx/extras-available/ && \
+mkdir -p /etc/nginx/extras-enabled/ && \
 rm -Rf /var/www/* && \
 mkdir /var/www/html/
 
 COPY ./nginx/default.conf /etc/nginx/sites-available/default.conf
 RUN ln -s /etc/nginx/sites-available/default.conf /etc/nginx/sites-enabled/default.conf
+
+# nginx default errors
+COPY ./errors/ /var/www/errors/
+
+# nginx override configs enabled by specific config options
+COPY ./nginx/extras/ /etc/nginx/extras-available/
 
 # tweak php-fpm config
 RUN echo "cgi.fix_pathinfo=0" > ${php_vars} &&\

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
 # docker-nginx-php-fpm
 Docker container with Nginx and PHP-FPM in one
+
+## Config
+
+Any files added to the `sites-enabled` folder will be loaded so in addition to the `default.conf` you may want to redirect multiple domains to a new owner
+
+Example:
+
+`/etc/nginx/sites-enabled/old-domains.conf`
+
+```
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name www.old-name.com old-name.com;
+    return 301 $scheme://www.new-name.com$request_uri;
+}
+```
+
+
+Any `*.conf` files added to the `extras-enabled` folder will be added inside the primary `server{}` directive.
+
+Examples:
+
+`/etc/nginx/extras-enabled/rewrites.conf`
+
+```
+rewrite ^(/download/.*)/media/(\w+)\.?.*$ $1/mp3/$2.mp3 last;
+```
+
+`/etc/nginx/extras-enabled/security.conf`
+
+```
+location ~ .(aspx|php|jsp|cgi)$ {
+    deny all;
+}
+```
+
+## Wordpress
+
+Trailing slash URLs enabled by default if `WP_ENV` is present
+
+### Bedrock
+
+Enable rewrite rules with ENV `WP_FRAMEWORK=bedrock`
+
+### Multisite
+
+Add the following rules to `/etc/nginx/extras-enabled/rewrites.conf`
+
+```
+rewrite ^(/[^/]+)?(/wp-.*) $2 last;
+rewrite ^(/[^/]+)?(/.*\.php) $2 last;
+```
+
+## Troubleshooting
+
+### Increase nginx pm.max_childen
+
+**/etc/php/7.0/fpm/pool.d/www.conf**
+
+```
+[php-fpm-pool-settings]
+pm = dynamic
+pm.max_children = 25
+pm.start_servers = 10
+pm.min_spare_servers = 5
+pm.max_spare_servers = 20
+pm.max_requests = 500
+```
+
+To get an idea of what to use for the `pm.max_children`, you can use this calculation: _pm.max_children_ = _Total RAM dedicated to the web server_ / _Max child process size_.
+
+ Remember to leave some RAM for extra services you have running on your system.
+
+Determine the memory used by each (PHP-FPM) child process
+
+```
+procps -ylC php-fpm7.2 --sort:rss
+```
+
+Check an average memory usage by single PHP-FPM process
+
+```
+procps --no-headers -o "rss,cmd" -C php-fpm | awk '{ sum+=$1 } END { printf ("%d%s\n", sum/NR/1024,"M") }'
+```

--- a/errors/4xx.html
+++ b/errors/4xx.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <style type="text/css">a {text-decoration: none}</style>
+  <style type="text/css">body {text-align: center}</style>
+  <title>Error</title>
+</head>
+<body>
+   <img src="/sad.svg"/>
+   <br/>
+   <h2>Resource has moved or is unavailable</h2>
+</body>
+</html>

--- a/errors/5xx.html
+++ b/errors/5xx.html
@@ -4,11 +4,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <style type="text/css">a {text-decoration: none}</style>
   <style type="text/css">body {text-align: center}</style>
-  <title>Error - 404</title>
+  <title>Error</title>
 </head>
 <body>
-   <img src="./sad.svg"/>
+   <img src="/sad.svg"/>
    <br/>
-   <h2>Page not Found</h2>
+   <h2>Resource is broken or temporarily unavailable</h2>
 </body>
 </html>

--- a/errors/error-handler.php
+++ b/errors/error-handler.php
@@ -1,0 +1,21 @@
+<?php
+
+$error_code = (int)$_GET['code'] ?? 500;
+http_response_code($error_code);
+
+// Example of custom error handlers
+/*
+switch($error_code) {
+  case 404:
+    print "404 Not Found";
+    break;
+
+  case 502:
+    print "Bad Gateway";
+    break;
+}
+*/
+
+exit();
+
+?>

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -35,31 +35,12 @@ server {
       access_log off;
   }
 
-  ## Protect the readme.html file to not reveal the installed
-  ## version.
-  location = /readme.html {
-      auth_basic "Restricted Access"; # auth realm
-      auth_basic_user_file .htpasswd-users; # htpasswd file
-  }
-
 	## Health check endpoint
 	location /healthz {
       access_log off;
 			add_header Content-Type text/plain;
       return 200 "OK\n";
   }
-
-  # Bedrock rewrite
-  if (!-e $request_filename) {
-    rewrite ^/(wp-.*.php)$ /wp/$1 last;
-    rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
-  }
-
-  if (!-e $request_filename) {
-		rewrite /wp-admin$ $scheme://$host$uri/ permanent;
-		rewrite ^(/[^/]+)?(/wp-.*) $2 last;
-		rewrite ^(/[^/]+)?(/.*\.php) $2 last;
-	}
 
 	# Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
 	sendfile off;
@@ -72,7 +53,7 @@ server {
   #real_ip_header X-Forwarded-For;
   #set_real_ip_from 172.16.0.0/12;
 
-  location / {
+	location / {
 	 try_files $uri $uri/ /index.php?$args;
 	}
 
@@ -82,24 +63,53 @@ server {
 	#	try_files $uri $uri/ =404;
 	#}
 
-	error_page 404 /404.html;
-  location = /404.html {
-          root /var/www/errors;
-          internal;
-  }
+
+	# 404 intentionally omitted so it can be set by application
+	# TO-DO make the start.sh allow replacing the default 404 with a variable route using sed
+	# error_page 401 403 405 /errors/4xx.html;
+	# error_page 500 501 502 503 504 /errors/5xx.html;
+	# location ^~ /errors/ {
+	#	 internal;
+	#	 root /var/www;
+	# }
+
+  # Redirect common non-404 errors to custom handler
+	error_page 401 403 405 500 501 502 503 504 /errors/error-handler.php?code=$status;
+
+	location = /errors/error-handler.php {
+		internal;
+		root /var/www;
+
+    include /etc/nginx/fastcgi_params;
+    fastcgi_pass unix:/var/run/php-fpm.sock;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+    fastcgi_intercept_errors off;
+	}
+
+	# location /test-error {
+  #     fastcgi_pass unix:/does/not/exist;
+  # }
 
   location ^~ /sad.svg {
-      alias /var/www/errors/sad.svg;
-      access_log off;
+    alias /var/www/errors/sad.svg;
+    access_log off;
   }
 
 	# pass the PHP scripts to FastCGI server listening on socket
 	#
 	location ~ \.php$ {
-    try_files $uri =404;
+    # try_files $uri =404;
+		try_files $uri /index.php?req=$uri&$args;
+
+		#NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
     include /etc/nginx/fastcgi_params;
+
+		# This sends all PHP erros to nginx, without it any response is logged as a 200
+		fastcgi_intercept_errors on;
+
     fastcgi_pass unix:/var/run/php-fpm.sock;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param SCRIPT_NAME $fastcgi_script_name;
@@ -107,12 +117,19 @@ server {
 	}
 
   ## All files/directories that are protected and unaccessible from the web.
-  location ~* ^.*(\.(?:git|svn|htaccess|txt|pot?))$ {
+  location ~* ^.*(\.(?:git|svn|htaccess|pot?))$ {
+      return 404;
+  }
+
+	## Protect readmes to not reveal sensitive information
+  location ~* ^.*(readme)\.(html|txt|md)$ {
       return 404;
   }
 
   ## Static files are served directly.
   location ~* \.(?:css|gif|htc|ico|js|jpe?g|png|swf)$ {
+			# Send missing file requests to index page so they can be handled by a dynamic 404
+			try_files $uri /index.php?req=$uri&$args;
       expires max;
   #    access_log off;
       log_not_found off;
@@ -161,12 +178,15 @@ server {
     auth_basic off;
   }
 
-  ## The 'final' attempt to serve the request.
+	## The 'final' attempt to serve the request.
   location @nocache {
-      try_files $uri $uri/ /index.php?q=$uri&$args;
+      try_files $uri $uri/ /index.php?req=$uri&$args;
   }
 
   # This should match upload_max_filesize in php.ini
 	client_max_body_size 100M;
   client_body_buffer_size 100M;
+
+	# Allow passing in extra directives for the site
+	include /etc/nginx/extras-enabled/*.conf;
 }

--- a/nginx/extras/trailing-slash.conf
+++ b/nginx/extras/trailing-slash.conf
@@ -1,0 +1,9 @@
+# 301 try_file for trailing slash and ignore wp-admin and wp-json requests for Wordpress sites
+location ~ ^(?!/wp-(admin|json))([^.\?]*[^/])$ { try_files $uri @addslash; }
+
+# 301 redirect for trailing slash if `@addslash` is set
+location @addslash {
+  absolute_redirect off;
+
+  return 301 $uri/$is_args$args;
+}

--- a/nginx/extras/wordpress-bedrock.conf
+++ b/nginx/extras/wordpress-bedrock.conf
@@ -1,0 +1,12 @@
+# Wordpress rewrites for Bedrock framework
+location ~ ^/wp-(?!(json)).*$ {
+  absolute_redirect off;
+
+  # Simple AJAX route
+  rewrite ^/wp-ajax(.*)$ /wp/wp-admin/admin-ajax.php$1 permanent;
+
+	# Bedrock rewrites
+	rewrite ^/wp-content/(.*) /app/$1 permanent;
+  rewrite ^/(wp-[^.]+\.php)$ /wp/$1 permanent;
+  rewrite ^/(wp-(admin|includes).*) /wp/$1 permanent;
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -42,16 +42,6 @@ if [[ "$REAL_IP_HEADER" == "1" ]] ; then
   sed -i "s#172.16.0.0/12#$REAL_IP_FROM#" /etc/nginx/sites-available/default.conf
  fi
 fi
-# Do the same for SSL sites
-if [ -f /etc/nginx/sites-available/default-ssl.conf ]; then
- if [[ "$REAL_IP_HEADER" == "1" ]] ; then
-  sed -i "s/#real_ip_header X-Forwarded-For;/real_ip_header X-Forwarded-For;/" /etc/nginx/sites-available/default-ssl.conf
-  sed -i "s/#set_real_ip_from/set_real_ip_from/" /etc/nginx/sites-available/default-ssl.conf
-  if [ ! -z "$REAL_IP_FROM" ]; then
-   sed -i "s#172.16.0.0/12#$REAL_IP_FROM#" /etc/nginx/sites-available/default-ssl.conf
-  fi
- fi
-fi
 
 #Display errors in docker logs
 if [ ! -z "$PHP_ERRORS_STDERR" ]; then
@@ -104,6 +94,16 @@ else
         echo "Disabling Xdebug"
       rm $XdebugFile
     fi
+fi
+
+# Trailing slash for Wordpress sites or explicitly set
+if [[ ! -z "$WP_ENV" || "$TRAILING_SLASH" == "1" ]] ; then
+  ln -sfn /etc/nginx/extras-available/trailing-slash.conf /etc/nginx/extras-enabled/
+fi
+
+# Wordpress Bedrock rules
+if [[ "$WP_FRAMEWORK" == "bedrock" ]] ; then
+  ln -sfn /etc/nginx/extras-available/wordpress-bedrock.conf /etc/nginx/extras-enabled/
 fi
 
 if [ ! -z "$PUID" ]; then


### PR DESCRIPTION
- Resolve PHP errors with fastcgi and send to PHP error handler which can be overridden by a container 
- Send failed physical files to index.php so they can be resolved by the application which is typical in PHP
- Moved Wordpress-specific rules out and into new `/etc/nginx/extras-available` folder. When passing the ENV `TRAILING_SLASH` or `WP_ENV` then **trailing-slash.conf** is enabled and when passing the ENV `WP_FRAMEWORK=bedrock` then **wordpress-bedrock.conf** is enabled by symlinking them into the `extras-enabled` folder. Any **.conf** file can be mapped directly into `/etc/nginx/extras-enabled` folder as well for container-specific rules.